### PR TITLE
fix: move dust transfer

### DIFF
--- a/src/ERC20CreatorV3.sol
+++ b/src/ERC20CreatorV3.sol
@@ -223,16 +223,6 @@ contract ERC20CreatorV3 is IERC721Receiver {
             token.transfer(tokenRecipientAddress, config.numTokensForRecipient);
         }
 
-        // Transfer fee
-        if (feeAmount > 0) {
-            feeRecipient.call{value: feeAmount, gas: 100_000}("");
-        }
-
-        // Transfer remaining ETH to the party
-        if (address(this).balance > 0) {
-            payable(party).call{value: address(this).balance}("");
-        }
-
         // Refund any remaining dust of the token to the party
         {
             uint256 remainingTokenBalance = token.balanceOf(address(this));
@@ -241,6 +231,16 @@ contract ERC20CreatorV3 is IERC721Receiver {
                 config.numTokensForLP -= remainingTokenBalance;
                 token.transfer(party, remainingTokenBalance);
             }
+        }
+
+        // Transfer fee
+        if (feeAmount > 0) {
+            feeRecipient.call{value: feeAmount, gas: 100_000}("");
+        }
+
+        // Transfer remaining ETH to the party
+        if (address(this).balance > 0) {
+            payable(party).call{value: address(this).balance}("");
         }
 
         PositionData memory positionData = PositionData({


### PR DESCRIPTION
From alexxander:
> It might be better to move the newly introduced token dust refund before transferring ETH to the feeRecipient and sweeping the excess ETH. This is to maintain a better code standard where the ETH transfers happen last. We couldn't find an exploit scenario since we assume feeRecipient and tokenRecipientAddress are trusted.